### PR TITLE
Fix crash on interface shutdown

### DIFF
--- a/roboteam_ai/include/roboteam_ai/STPManager.h
+++ b/roboteam_ai/include/roboteam_ai/STPManager.h
@@ -31,7 +31,7 @@ class STPManager {
     void decidePlay(world::World* _world);
 
    public:
-    void start();
+    void start(std::atomic_bool& exitApplication);
 
     /**
      * The vector that contains all plays

--- a/roboteam_ai/src/STPManager.cpp
+++ b/roboteam_ai/src/STPManager.cpp
@@ -44,7 +44,7 @@ namespace ai = rtt::ai;
 namespace rtt {
 
 /// Start running behaviour trees. While doing so, publish settings and log the FPS of the system
-void STPManager::start() {
+void STPManager::start(std::atomic_bool& exitApplication) {
     // make sure we start in halt state for safety
     ai::GameStateManager::forceNewGameState(RefCommand::HALT, std::nullopt);
     RTT_INFO("Start looping")
@@ -115,6 +115,9 @@ void STPManager::start() {
             // If this is primary AI, broadcast settings every second
             if (SETTINGS.isPrimaryAI()) {
                 stpTimer.limit([&]() { io::io.publishSettings(SETTINGS); }, ai::Constants::SETTINGS_BROADCAST_RATE());
+            }
+            if(exitApplication){
+                stpTimer.stop();
             }
         },
         ai::Constants::STP_TICK_RATE());


### PR DESCRIPTION
Make sure we cleanly exit instead of segfaulting by joining the thread when it is not done yet.
This was bothering me when running the AI, so I fixed it.