### PR TITLE
Increase warning level and fix warnings in roboteam_utils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ else ()
 endif ()
 
 # Build type compile flags
-set(DEBUG_COMPILE_FLAGS "${CPP_STANDARD_FLAG}" "-fPIC" "-Wall" "-g" "-Og" "-march=native" "-fdiagnostics-color=always")
+set(DEBUG_COMPILE_FLAGS "${CPP_STANDARD_FLAG}" "-fPIC" "-g" "-Og" "-Wall" "-Wextra" "-Wnon-virtual-dtor" "-pedantic" "-fdiagnostics-color=always")
 set(RELEASE_COMPILE_FLAGS "${CPP_STANDARD_FLAG}" "-fPIC" "-Ofast" "-march=native" "-fdiagnostics-color=always")
 
 # Specify manually which compiler arguments we want to use, either DEBUG (default) or RELEASE ones

--- a/roboteam_utils/include/roboteam_utils/Shape.h
+++ b/roboteam_utils/include/roboteam_utils/Shape.h
@@ -11,9 +11,11 @@
 namespace rtt {
     class Shape {
     public:
-        virtual bool contains(const Vector2& point) const = 0;
+        [[nodiscard]] virtual bool contains(const Vector2& point) const = 0;
 
-        virtual Vector2 project(const Vector2& point) const = 0;
+        [[nodiscard]] virtual Vector2 project(const Vector2& point) const = 0;
+
+        virtual ~Shape() = default;
     };
 }
 

--- a/roboteam_utils/src/utils/LazyRectangle.cpp
+++ b/roboteam_utils/src/utils/LazyRectangle.cpp
@@ -1,5 +1,6 @@
 #include "LazyRectangle.hpp"
 
+#include <cassert>
 #include <cmath>
 
 #include "Line.h"
@@ -108,7 +109,8 @@ std::vector<Vector2> LazyRectangle::intersects(const LineSegment &line) const {
             } else if (codeOut & RIGHT) {  // point is to the right of clip window
                 y = y0 + (y1 - y0) * (right() - x0) / (x1 - x0);
                 x = right();
-            } else if (codeOut & LEFT) {  // point is to the left of clip window
+            } else{  // point is to the left of clip window
+                assert(codeOut & LEFT);
                 y = y0 + (y1 - y0) * (left() - x0) / (x1 - x0);
                 x = left();
             }

--- a/roboteam_utils/test/utils/LineSegmentTest.cpp
+++ b/roboteam_utils/test/utils/LineSegmentTest.cpp
@@ -39,7 +39,8 @@ TEST(LineSegmentTests, center) {
 
         auto distCenterStart = lineSeg.center().dist(lineSeg.start);
         auto distCenterEnd = lineSeg.center().dist(lineSeg.end);
-        ASSERT_DOUBLE_EQ(distCenterStart, distCenterEnd);
+        ASSERT_TRUE(std::fabs(distCenterStart-distCenterEnd) < 1e-12); //ASSERT_DOUBLE_EQ can fail here due to small numerical errors for nearly parallel lines,
+                                                                       //though these errors should really stay small in practice.
     }
 }
 


### PR DESCRIPTION
I increased the warnings in debug to contain some commonly used flags which are recommended by most if not all sources to prevent bugs. I fixed the warnings I found in roboteam_utils.