### PR TITLE
Fixed the onlyDecelerateOtherWay test in BBTrajectory1DTest.cpp

### DIFF
--- a/roboteam_ai/test/ControlTests/BBTrajectory/BBTrajectory1DTest.cpp
+++ b/roboteam_ai/test/ControlTests/BBTrajectory/BBTrajectory1DTest.cpp
@@ -49,7 +49,7 @@ TEST(BBTrajectories, onlyDecelerateOtherWay) {
     EXPECT_DOUBLE_EQ(test.getVelocity(2), 0);
     EXPECT_DOUBLE_EQ(test.getVelocity(3), 0);
     // TODO: fix buggy parts
-    EXPECT_TRUE(test.inLastPart(0.000));
-    EXPECT_TRUE(test.inLastPart(1.5));
+    EXPECT_FALSE(test.inLastPart(0.000));
+    EXPECT_TRUE(test.inLastPart(2.5));
 }
 }  // namespace rtt::BB


### PR DESCRIPTION
The test was wrongly assuming that t=0 and t=1.5 should be in the last part of the trajectory. This is not the case as a trajectory consists of 3 parts, so the last part should be between t=2 and t=3. The test now checks if t=0 is outside the last part and if t=2.5 is inside the last part.

### Comments for the reviewer
- 

### Pre pull request checklist:

###### Code Quality
- [ x] Is the code is understandable and easy to read
- [ x] Changes to the code comply with set clang-format rules
- [ x] No use of manual memory control (e.g new/malloc/colloc etc)
- [x ] Are (only) smart pointers used? no pointers are use

###### Testing
- [ x] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ x] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ x] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
