### PR TITLE
Added flags for ips and ports; Added some user feedback (shouldnt impact performance);

### DIFF
--- a/roboteam_world/include/roboteam_observer/Handler.h
+++ b/roboteam_world/include/roboteam_observer/Handler.h
@@ -32,9 +32,9 @@ class Handler {
      * Setup a world with a kalmanfilter, and initialize the publishers for publishing data.
      */
     bool initializeNetworkers();
-    bool setupSSLClients();
+    bool setupSSLClients(std::string visionip, std::string refereeip, int visionport, int refereeport);
 
-    void start(bool shouldLog = false);
+    void start(std::string visionip, std::string refereeip, int visionport, int refereeport, bool shouldLog = false);
     std::vector<proto::SSL_WrapperPacket> receiveVisionPackets();
     std::vector<proto::SSL_Referee> receiveRefereePackets();
     void onRobotFeedback(const rtt::RobotsFeedback& feedback);

--- a/roboteam_world/src/Handler.cpp
+++ b/roboteam_world/src/Handler.cpp
@@ -7,11 +7,11 @@
 
 #include <roboteam_logging/LogFileWriter.h>
 
-void Handler::start(bool shouldLog) {
+void Handler::start(std::string visionip, std::string refereeip, int visionport, int refereeport, bool shouldLog) {
     if (!initializeNetworkers()) {
         throw FailedToInitializeNetworkersException();
     }
-    if (!this->setupSSLClients()) {
+    if (!this->setupSSLClients(visionip, refereeip, visionport, refereeport)) {
         throw FailedToSetupSSLClients();
     }
 
@@ -33,10 +33,39 @@ void Handler::start(bool shouldLog) {
         fileWriter.value().open(file_name);
     }
 
+    // Feedback for user
+    int no_vision_received = 0;
+    bool receiving_vision = true;
+    std::cout << std::endl << "\rReceiving vision packets" << std::flush;
+
     t.loop(
         [&]() {
             auto vision_packets = receiveVisionPackets();
             auto referee_packets = receiveRefereePackets();
+
+            // Feedback to user
+            if (vision_packets.empty()) {
+                no_vision_received++;
+                receiving_vision = no_vision_received < 100;
+                if (0 < no_vision_received && no_vision_received % 50 == 0) {
+                    std::cout << "\rNot receiving vision packets ";
+                    // Print spinner to show that program is still running
+                         if(no_vision_received % 200 <  50) std::cout << "|";
+                    else if(no_vision_received % 200 < 100) std::cout << "/";
+                    else if(no_vision_received % 200 < 150) std::cout << "-";
+                    else if(no_vision_received % 200 < 200) std::cout << "\\";
+                    std::cout << std::flush;
+                }
+            } else {
+                // Only print this once. If we're receiving packets, we don't want to influence processing time with slow std::cout calls
+                if(!receiving_vision){
+                    std::cout << "\rReceiving vision packets        \r" << std::flush;
+                    std::cout << "tick" << std::endl;
+                    receiving_vision = true;
+                }
+                no_vision_received = 0;
+            }
+            
             std::vector<rtt::RobotsFeedback> robothub_info;
             {
                 std::lock_guard guard(sub_mutex);
@@ -77,20 +106,27 @@ bool Handler::initializeNetworkers() {
     return this->worldPublisher != nullptr && this->feedbackSubscriber != nullptr;
 }
 
-bool Handler::setupSSLClients() {
+bool Handler::setupSSLClients(std::string visionip, std::string refereeip, int visionport, int refereeport) {
     bool success = true;
-    constexpr quint16 DEFAULT_VISION_PORT = 10006;
-    constexpr quint16 DEFAULT_REFEREE_PORT = 10003;
 
-    const QString SSL_VISION_SOURCE_IP = "224.5.23.2";
-    const QString SSL_REFEREE_SOURCE_IP = "224.5.23.1";
+    const QString SSL_VISION_SOURCE_IP = QString::fromStdString(visionip);
+    const QString SSL_REFEREE_SOURCE_IP = QString::fromStdString(refereeip);
     
-    this->vision_client = std::make_unique<RobocupReceiver<proto::SSL_WrapperPacket>>(QHostAddress(SSL_VISION_SOURCE_IP),DEFAULT_VISION_PORT);
-    this->referee_client = std::make_unique<RobocupReceiver<proto::SSL_Referee>>(QHostAddress(SSL_REFEREE_SOURCE_IP),DEFAULT_REFEREE_PORT);
+    QHostAddress visionAddress(SSL_VISION_SOURCE_IP);
+    QHostAddress refereeAddress(SSL_REFEREE_SOURCE_IP);
 
-    success = vision_client != nullptr && referee_client != nullptr;
-    std::cout << "Vision  : " << SSL_VISION_SOURCE_IP.toStdString() << ":" << DEFAULT_VISION_PORT << std::endl;
-    std::cout << "Referee  : " << SSL_REFEREE_SOURCE_IP.toStdString() << ":" << DEFAULT_REFEREE_PORT << std::endl;
+    success &= !(visionAddress.isNull());
+    success &= !(refereeAddress.isNull());
+
+    if(visionAddress.isNull()) std::cout << "Error! Invalid vision ip-address: " << visionip << std::endl;
+    if(refereeAddress.isNull()) std::cout << "Error! Invalid referee ip-address: " << refereeip << std::endl;
+
+    this->vision_client = std::make_unique<RobocupReceiver<proto::SSL_WrapperPacket>>(visionAddress, visionport);
+    this->referee_client = std::make_unique<RobocupReceiver<proto::SSL_Referee>>(refereeAddress, refereeport);
+
+    success &= vision_client != nullptr && referee_client != nullptr;
+    std::cout << "Vision  : " << SSL_VISION_SOURCE_IP.toStdString() << ":" << visionport << std::endl;
+    std::cout << "Referee : " << SSL_REFEREE_SOURCE_IP.toStdString() << ":" << refereeport << std::endl;
 
     success &= vision_client->connect();
     success &= referee_client->connect();

--- a/roboteam_world/src/Handler.cpp
+++ b/roboteam_world/src/Handler.cpp
@@ -60,7 +60,6 @@ void Handler::start(std::string visionip, std::string refereeip, int visionport,
                 // Only print this once. If we're receiving packets, we don't want to influence processing time with slow std::cout calls
                 if(!receiving_vision){
                     std::cout << "\rReceiving vision packets        \r" << std::flush;
-                    std::cout << "tick" << std::endl;
                     receiving_vision = true;
                 }
                 no_vision_received = 0;

--- a/roboteam_world/src/Handler.cpp
+++ b/roboteam_world/src/Handler.cpp
@@ -106,13 +106,13 @@ bool Handler::initializeNetworkers() {
 }
 
 bool Handler::setupSSLClients(std::string visionip, std::string refereeip, int visionport, int refereeport) {
+    std::cout << "Vision  : " << visionip << ":" << visionport << std::endl;
+    std::cout << "Referee : " << refereeip << ":" << refereeport << std::endl;
+    
     bool success = true;
 
-    const QString SSL_VISION_SOURCE_IP = QString::fromStdString(visionip);
-    const QString SSL_REFEREE_SOURCE_IP = QString::fromStdString(refereeip);
-    
-    QHostAddress visionAddress(SSL_VISION_SOURCE_IP);
-    QHostAddress refereeAddress(SSL_REFEREE_SOURCE_IP);
+    QHostAddress visionAddress(QString::fromStdString(visionip));
+    QHostAddress refereeAddress(QString::fromStdString(refereeip));
 
     success &= !(visionAddress.isNull());
     success &= !(refereeAddress.isNull());
@@ -124,9 +124,7 @@ bool Handler::setupSSLClients(std::string visionip, std::string refereeip, int v
     this->referee_client = std::make_unique<RobocupReceiver<proto::SSL_Referee>>(refereeAddress, refereeport);
 
     success &= vision_client != nullptr && referee_client != nullptr;
-    std::cout << "Vision  : " << SSL_VISION_SOURCE_IP.toStdString() << ":" << visionport << std::endl;
-    std::cout << "Referee : " << SSL_REFEREE_SOURCE_IP.toStdString() << ":" << refereeport << std::endl;
-
+    
     success &= vision_client->connect();
     success &= referee_client->connect();
     std::this_thread::sleep_for(std::chrono::microseconds(10000));

--- a/roboteam_world/src/main.cpp
+++ b/roboteam_world/src/main.cpp
@@ -1,6 +1,6 @@
 #include "Handler.h"
 
-std::optional<std::string> findFlagValue(const std::vector<std::string> args, std::string flag){
+std::optional<std::string> findFlagValue(const std::vector<std::string>& args, std::string flag){
     // Search for flag
     auto it = std::find(args.begin(), args.end(), flag);
     // If flag is present in arguments
@@ -53,8 +53,8 @@ int main(int argc, char** argv) {
     val = findFlagValue(args, "--referee-port");
     if(val){ refereeport_str = *val; }
 
-    int visionport  = std::stoi( visionport_str.c_str() );
-    int refereeport = std::stoi( refereeport_str.c_str() );
+    int visionport  = std::stoi( visionport_str );
+    int refereeport = std::stoi( refereeport_str );
 
     Handler handler;
     handler.start(visionip, refereeip, visionport, refereeport, shouldLog);

--- a/roboteam_world/src/main.cpp
+++ b/roboteam_world/src/main.cpp
@@ -1,10 +1,60 @@
 #include "Handler.h"
 
+std::optional<std::string> findFlagValue(int argc, char** argv, std::string flag){
+    // Search for flag
+    auto it = std::find(argv, argv + argc, flag);
+    // If flag is present in arguments
+    if(it < argv + argc){
+        // No value found for flag.. 
+        if(argc < it - argv + 2){
+            std::cout << "Warning! flag '" << flag << "' raised but no value given." << std::endl << std::endl;
+            return std::nullopt;
+        }
+        // Return value right after flag
+        return { *(it + 1) };
+    }   
+
+    // Flag not present, return "nothing"
+    return std::nullopt;
+}
+
 int main(int argc, char** argv) {
-    auto itLog = std::find(argv, argv + argc, std::string("-log"));
+    std::cout << "Usage: ./roboteam_observer --log --vision-ip <ip-address> --referee-ip <ip-address> --vision-port <port> --referee-port <port>" << std::endl;
+    std::cout << "  log: log data to file" << std::endl;
+    std::cout << "  vision-ip  : ip to listen for vision.  Defaults to 224.5.23.2" << std::endl;
+    std::cout << "  referee-ip : ip to listen for referee. Defaults to 224.5.23.1" << std::endl;
+    std::cout << "  vision-port  : port to listen for vision.  Defaults to 10006 (use 10020 for ER-Force simulator)" << std::endl;
+    std::cout << "  referee-port : port to listen for referee. Defaults to 10003" << std::endl;
+
+    std::cout << std::endl;
+
+    std::string visionip = "224.5.23.2";
+    std::string refereeip = "224.5.23.1";
+    std::string visionport_str = "10006";
+    std::string refereeport_str = "10003";
+
+    // Search for log flag --log
+    auto itLog = std::find(argv, argv + argc, std::string("--log"));
     bool shouldLog = itLog != argv + argc;
 
+    std::optional<std::string> val;
+
+    val = findFlagValue(argc, argv, "--vision-ip");
+    if(val) visionip = *val;
+
+    val = findFlagValue(argc, argv, "--referee-ip");
+    if(val) refereeip = *val;
+
+    val = findFlagValue(argc, argv, "--vision-port");
+    if(val) visionport_str = *val;
+
+    val = findFlagValue(argc, argv, "--referee-port");
+    if(val) refereeport_str = *val;
+
+    int visionport  = atoi( visionport_str.c_str() );
+    int refereeport = atoi( refereeport_str.c_str() );
+
     Handler handler;
-    handler.start(shouldLog);
+    handler.start(visionip, refereeip, visionport, refereeport, shouldLog);
     return 0;
 }

--- a/roboteam_world/src/main.cpp
+++ b/roboteam_world/src/main.cpp
@@ -1,12 +1,12 @@
 #include "Handler.h"
 
-std::optional<std::string> findFlagValue(int argc, char** argv, std::string flag){
+std::optional<std::string> findFlagValue(const std::vector<std::string> args, std::string flag){
     // Search for flag
-    auto it = std::find(argv, argv + argc, flag);
+    auto it = std::find(args.begin(), args.end(), flag);
     // If flag is present in arguments
-    if(it < argv + argc){
+    if(it != args.end()){
         // No value found for flag.. 
-        if(argc < it - argv + 2){
+        if(it == args.end() - 1){
             std::cout << "Warning! flag '" << flag << "' raised but no value given." << std::endl << std::endl;
             return std::nullopt;
         }
@@ -33,26 +33,28 @@ int main(int argc, char** argv) {
     std::string visionport_str = "10006";
     std::string refereeport_str = "10003";
 
+    const std::vector<std::string> args(argv, argv + argc); 
+
     // Search for log flag --log
-    auto itLog = std::find(argv, argv + argc, std::string("--log"));
-    bool shouldLog = itLog != argv + argc;
+    auto itLog = std::find(args.begin(), args.end(), std::string("--log"));
+    bool shouldLog = itLog != args.end();
 
     std::optional<std::string> val;
 
-    val = findFlagValue(argc, argv, "--vision-ip");
-    if(val) visionip = *val;
+    val = findFlagValue(args, "--vision-ip");
+    if(val){ visionip = *val; }
 
-    val = findFlagValue(argc, argv, "--referee-ip");
-    if(val) refereeip = *val;
+    val = findFlagValue(args, "--referee-ip");
+    if(val){ refereeip = *val; }
 
-    val = findFlagValue(argc, argv, "--vision-port");
-    if(val) visionport_str = *val;
+    val = findFlagValue(args, "--vision-port");
+    if(val){ visionport_str = *val; }
 
-    val = findFlagValue(argc, argv, "--referee-port");
-    if(val) refereeport_str = *val;
+    val = findFlagValue(args, "--referee-port");
+    if(val){ refereeport_str = *val; }
 
-    int visionport  = atoi( visionport_str.c_str() );
-    int refereeport = atoi( refereeport_str.c_str() );
+    int visionport  = std::stoi( visionport_str.c_str() );
+    int refereeport = std::stoi( refereeport_str.c_str() );
 
     Handler handler;
     handler.start(visionip, refereeip, visionport, refereeport, shouldLog);


### PR DESCRIPTION
I added four flags to roboteam_observer: vision-ip, referee-ip, vision-port, referee-port. I found myself having to manually modify and recompile roboteam_observer if I wanted to switch ip or ports. Next to that I added a little user feedback, where it says "Not receiving vision packets" or "Receiving vision packets". The latter is only printed once, not on a loop, so it should not impact performance. I tested everything and it works well imo.