### PR TITLE
Fix/outdated world data

### DIFF
--- a/roboteam_ai/include/roboteam_ai/STPManager.h
+++ b/roboteam_ai/include/roboteam_ai/STPManager.h
@@ -34,8 +34,9 @@ class STPManager {
     /**
      * @brief Function that decides whether to change plays given a world and field.
      * @param _world the current world state
+     * @param ignoreWorldAge Whether to ignore the age of the world
      */
-    void decidePlay(world::World* _world);
+    void decidePlay(world::World* _world, bool ignoreWorldAge = false);
 
    public:
     /**

--- a/roboteam_ai/include/roboteam_ai/utilities/Constants.h
+++ b/roboteam_ai/include/roboteam_ai/utilities/Constants.h
@@ -20,7 +20,6 @@ typedef std::tuple<double, double, double> pidVals; /**< Defenition of the pidVa
 class Constants {
    public:
     static void init(); /**< Initializes the constants for either the simulator or basestation. */
-    static bool GRSIM(); /**< Checks whether we are using grsim or the basestation */
     static bool FEEDBACK_ENABLED(); /**< Checks whether robot feedback is enabled */
 
     /**
@@ -112,10 +111,6 @@ class Constants {
     static pidVals standardInterceptPID(); /**< The standard PID values for Intercept */
     static pidVals standardKeeperPID(); /**< The standard PID values for Keeper*/
     static pidVals standardKeeperInterceptPID(); /**< The standard PID values for KeeperIntercept */
-
-   private:
-    static bool isInitialized; /**< Keeps track of whether the AI is initialized */
-    static bool robotOutputTargetGrSim; /**< Keeps track of whether the output should go to GrSim */
 };
 
 }  // namespace rtt::ai

--- a/roboteam_ai/include/roboteam_ai/utilities/Constants.h
+++ b/roboteam_ai/include/roboteam_ai/utilities/Constants.h
@@ -23,6 +23,12 @@ class Constants {
     static bool FEEDBACK_ENABLED(); /**< Checks whether robot feedback is enabled */
 
     /**
+     * @brief Indicates the maximum amount of time the AI can run without receiving a new world update
+     * @return The maximum amount of time
+     */
+    static constexpr uint64_t WORLD_MAX_AGE_MILLISECONDS() { return 1000; }
+
+    /**
      * @brief Checks the amount of robots present
      * @return The amount of robots
      */

--- a/roboteam_ai/include/roboteam_ai/utilities/Pause.h
+++ b/roboteam_ai/include/roboteam_ai/utilities/Pause.h
@@ -25,29 +25,29 @@ class Pause {
     static bool pause; /**< Indicates whether the robots are paused */
     static std::mutex pauseLock; /**< Synchronizer for the pause button */
 
-   public:
     /**
-     * @brief Constructor for the Pause class
+     * @brief Constructor for the Pause class. No instance should ever be needed
      */
     Pause();
 
+   public:
     /**
      * @brief Getter for the pause boolean
      * @return Whether the robots are paused
      */
-    bool getPause();
+    static bool getPause();
 
     /**
      * @brief Halts the robots
      * @param data The current world
      */
-    void haltRobots(rtt::world::World const* data);
+    static void haltRobots(rtt::world::World const* data);
 
     /**
      * @brief Sets the pause boolean
      * @param set The value to which the pause boolean should be set
      */
-    void setPause(bool set);
+    static void setPause(bool set);
 };
 }  // namespace rtt::ai
 

--- a/roboteam_ai/src/interface/api/Output.cpp
+++ b/roboteam_ai/src/interface/api/Output.cpp
@@ -25,16 +25,16 @@ std::mutex Output::refMutex;
 GameState Output::interfaceGameState("halt_strategy", "default");
 
 void Output::sendHaltCommand() {
-    rtt::ai::Pause pause;
     auto const &[_, world] = rtt::world::World::instance();
-    // TODO: This check prevents a segfault when we don't have a world (roobthub_world is off), but it should be checked earlier I think
+    // TODO: This check prevents a segfault when we don't have a world (roboteam_observer is off), but it should be checked earlier I think
     if (world->getWorld().has_value()) {
-        if (pause.getPause()) {
+        if (rtt::ai::Pause::getPause()) {
             // Already halted so unhalt
-            pause.setPause(false);
+            rtt::ai::Pause::setPause(false);
         } else {
-            pause.setPause(true);
-            pause.haltRobots(world);
+            rtt::ai::Pause::setPause(true);
+            // grSim will continue moving the robots unless halt commands are explicitly sent
+            rtt::ai::Pause::haltRobots(world);
         }
     }
 

--- a/roboteam_ai/src/interface/widgets/MainControlsWidget.cpp
+++ b/roboteam_ai/src/interface/widgets/MainControlsWidget.cpp
@@ -171,11 +171,13 @@ void MainControlsWidget::toggleRobotHubModeParam() {
 /// send a halt signal to stop all trees from executing
 void MainControlsWidget::sendPauseSignal() { 
     Output::sendHaltCommand();
-    rtt::ai::Pause p;
-    if(p.getPause()){
+
+    if(rtt::ai::Pause::getPause()){
         pauseBtn->setText("Start");
+        pauseBtn->setStyleSheet("background-color: #00cc00;");
     }else{
         pauseBtn->setText("Stop");
+        pauseBtn->setStyleSheet("background-color: #cc0000;");
     }
 
 

--- a/roboteam_ai/src/interface/widgets/MainControlsWidget.cpp
+++ b/roboteam_ai/src/interface/widgets/MainControlsWidget.cpp
@@ -169,7 +169,17 @@ void MainControlsWidget::toggleRobotHubModeParam() {
 }
 
 /// send a halt signal to stop all trees from executing
-void MainControlsWidget::sendPauseSignal() { Output::sendHaltCommand(); }
+void MainControlsWidget::sendPauseSignal() { 
+    Output::sendHaltCommand();
+    rtt::ai::Pause p;
+    if(p.getPause()){
+        pauseBtn->setText("Start");
+    }else{
+        pauseBtn->setText("Stop");
+    }
+
+
+}
 
 void MainControlsWidget::setToggleColorBtnLayout() const {
     if (SETTINGS.isYellow()) {

--- a/roboteam_ai/src/interface/widgets/widget.cpp
+++ b/roboteam_ai/src/interface/widgets/widget.cpp
@@ -11,6 +11,8 @@
 #include "utilities/GameStateManager.hpp"
 #include "utilities/IOManager.h"
 
+#include <chrono>
+
 namespace io = rtt::ai::io;
 namespace rtt::ai::interface {
 
@@ -28,6 +30,7 @@ void Visualizer::paintEvent(QPaintEvent *event) {
         auto const &world = worldPtr->getWorld();
         auto const &field = worldPtr->getField();
 
+
         if (!world.has_value()) {
             painter.drawText(24, 24, "Waiting for incoming world state");
             return;
@@ -39,6 +42,20 @@ void Visualizer::paintEvent(QPaintEvent *event) {
             drawFieldHints(field.value(), painter);
             drawFieldLines(field.value(), painter);
         }
+
+        /* Check if world is not too old*/
+        // Timestamp in miliseconds when AI received this world state
+        uint64_t ms_world = world.value().get()->getTime() / 1000000;
+        // Timestamp in miliseconds of current time
+        uint64_t ms_now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+        // Age of the world state in miliseconds
+        uint64_t ms_world_age = ms_now - ms_world;
+        // If world is too old, don't draw any robots or ball
+        if(rtt::ai::Constants::WORLD_MAX_AGE_MILLISECONDS() < ms_world_age) {
+            painter.drawText(24, 24, "World state is too old! Age: " + QString::number(ms_world_age) + " ms. Waiting for new world state..");
+            return;
+        }
+
 
         auto s = QString::fromStdString("We have " + std::to_string(world->getUs().size()) + " robots");
         painter.drawText(24, 48, s.fromStdString("We have " + std::to_string(world->getUs().size()) + " robots"));

--- a/roboteam_ai/src/interface/widgets/widget.cpp
+++ b/roboteam_ai/src/interface/widgets/widget.cpp
@@ -173,7 +173,7 @@ void Visualizer::calculateFieldSizeFactor(const rtt::Field &field) {
 
 /// draws background of the field
 void Visualizer::drawBackground(QPainter &painter) {
-    painter.setBrush(Constants::FIELD_COLOR());
+    painter.setBrush(QColor(30, 30, 30, 255));
     painter.drawRect(-10, -10, this->size().width() + 10, this->size().height() + 10);
 }
 

--- a/roboteam_ai/src/roboteam_ai.cpp
+++ b/roboteam_ai/src/roboteam_ai.cpp
@@ -52,8 +52,6 @@ int main(int argc, char* argv[]) {
 
     RTT_DEBUG("Debug prints enabled")
 
-    rtt::ai::Constants::init();
-
     // get the id of the ai from the init
     int id = *argv[1] - '0';
 

--- a/roboteam_ai/src/utilities/Constants.cpp
+++ b/roboteam_ai/src/utilities/Constants.cpp
@@ -13,24 +13,6 @@
 
 namespace rtt::ai {
 
-// static initializers
-bool Constants::isInitialized = false;
-bool Constants::robotOutputTargetGrSim = true;
-
-void Constants::init() {
-    std::string target = robotOutputTargetGrSim ? "GRSIM" : "SERIAL";
-    RTT_INFO("robot_output_target is set to ", target)
-    isInitialized = true;
-}
-
-bool Constants::GRSIM() {
-    if (!isInitialized) {
-        RTT_ERROR("You use a value dependent on an unkown environment! This may result in unexepected behaviour")
-        assert(false);
-    }
-    return robotOutputTargetGrSim;
-}
-
 double Constants::PENALTY_DISTANCE_BEHIND_BALL() {
     // The minimum is 1 meter, but do 1.5 to be sure
     return 1.5;
@@ -213,8 +195,6 @@ bool Constants::ROBOT_HAS_KICKER(int id) { return ROBOTS_WITH_KICKER()[id]; }
 
 int Constants::ROBOT_MAXIMUM_KICK_TIME(int id) { return ROBOTS_MAXIMUM_KICK_TIME()[id]; }
 
-QColor Constants::FIELD_COLOR() { return GRSIM() ? QColor(30, 30, 30, 255) : QColor(50, 0, 0, 255); }
-
 QColor Constants::FIELD_LINE_COLOR() { return Qt::white; }
 
 QColor Constants::ROBOT_COLOR_BLUE() { return {150, 150, 255, 255}; }
@@ -229,15 +209,15 @@ QColor Constants::SELECTED_ROBOT_COLOR() { return Qt::magenta; }
 
 std::vector<QColor> Constants::TACTIC_COLORS() { return {{255, 0, 255, 50}, {0, 255, 255, 50}, {255, 255, 0, 50}, {0, 255, 0, 50}, {0, 0, 255, 100}}; }
 
-pidVals Constants::standardNumTreePID() { return GRSIM() ? pidVals(2.5, 0.0, 0) : pidVals(2.5, 0.0, 0); }
+pidVals Constants::standardNumTreePID() { return SETTINGS.getRobotHubMode() == Settings::RobotHubMode::BASESTATION ? pidVals(2.5, 0.0, 0) : pidVals(2.5, 0.0, 0); }
 
-pidVals Constants::standardReceivePID() { return GRSIM() ? pidVals(4, 0, 0) : pidVals(4, 0, 0); }
+pidVals Constants::standardReceivePID() { return SETTINGS.getRobotHubMode() == Settings::RobotHubMode::BASESTATION ? pidVals(4, 0, 0) : pidVals(4, 0, 0); }
 
-pidVals Constants::standardInterceptPID() { return GRSIM() ? pidVals(6, 0, 1) : pidVals(6, 0, 1); }
+pidVals Constants::standardInterceptPID() { return SETTINGS.getRobotHubMode() == Settings::RobotHubMode::BASESTATION ? pidVals(6, 0, 1) : pidVals(6, 0, 1); }
 
-pidVals Constants::standardKeeperPID() { return GRSIM() ? pidVals(2.5, 0.0, 0) : pidVals(2.5, 0.0, 0); }
+pidVals Constants::standardKeeperPID() { return SETTINGS.getRobotHubMode() == Settings::RobotHubMode::BASESTATION ? pidVals(2.5, 0.0, 0) : pidVals(2.5, 0.0, 0); }
 
-pidVals Constants::standardKeeperInterceptPID() { return GRSIM() ? pidVals(6, 0, 1) : pidVals(6, 0, 1); }
+pidVals Constants::standardKeeperInterceptPID() { return SETTINGS.getRobotHubMode() == Settings::RobotHubMode::BASESTATION ? pidVals(6, 0, 1) : pidVals(6, 0, 1); }
 
 std::vector<RuleSet> Constants::ruleSets() {
     return {{"default", 2, 6.5, 0.0, ROBOT_RADIUS(), true},

--- a/roboteam_ai/src/utilities/Pause.cpp
+++ b/roboteam_ai/src/utilities/Pause.cpp
@@ -2,6 +2,7 @@
 // Created by baris on 15-2-19.
 //
 
+#include <roboteam_utils/Print.h>
 #include <roboteam_utils/RobotCommands.hpp>
 
 #include "utilities/IOManager.h"
@@ -16,6 +17,7 @@ bool Pause::getPause() {
     std::lock_guard<std::mutex> lock(pauseLock);
     return pause;
 }
+
 void Pause::haltRobots(rtt::world::World const* data) {
     auto us = data->getWorld()->getUs();
     std::vector<rtt::RobotCommand> commands;
@@ -30,10 +32,11 @@ void Pause::haltRobots(rtt::world::World const* data) {
     }
     io::io.publishAllRobotCommands(commands);
 }
+
 void Pause::setPause(bool set) {
+    RTT_INFO(set ? "Halting" : "Unhalting", " the AI")
     std::lock_guard<std::mutex> lock(pauseLock);
     pause = set;
 }
-Pause::Pause() {}
 
 }  // namespace rtt::ai


### PR DESCRIPTION
This PR does three things

1. It checks if the world data is older than 1000ms. If so, it halts all robots. Should prevent the robots from crashing into walls when SSL-Vision or roboteam_observer stops
2. It removes some unused stuff in Constants.cpp
3. The stop button now toggles between Stop (red) and Start (green)