### PR TITLE
[roboteam_ai] Temporary fix for issue #57

### DIFF
--- a/roboteam_ai/src/world/WorldData.cpp
+++ b/roboteam_ai/src/world/WorldData.cpp
@@ -20,12 +20,29 @@ WorldData::WorldData(const World *data, proto::World &protoMsg, rtt::Settings co
     them.reserve(amountThem);
     robots.reserve(amountUs + amountThem);
 
+    // NOTE: This is a (hopefully) temporary fix for issue #57 (https://github.com/RoboTeamTwente/roboteam/issues/57)
+    // for (auto &each : ours) {
+    //     robots.emplace_back( each, Team::us, getBall());
+    // }
+    // for (auto &each : others) {
+    //     robots.emplace_back( each, Team::them, getBall());
+    // }
+    
     for (auto &each : ours) {
-        robots.emplace_back( each, Team::us, getBall());
+        if(isnan(each.pos().x())){
+            RTT_ERROR("WATCH OUT! ROBOT WITH NAN VALUES RECEIVED FROM OBSERVER! Omitting robot for now..")
+        }else {
+            robots.emplace_back(each, Team::us, getBall());
+        }
     }
     for (auto &each : others) {
-        robots.emplace_back( each, Team::them, getBall());
+        if(isnan(each.pos().x())){
+            RTT_ERROR("WATCH OUT! ROBOT WITH NAN VALUES RECEIVED FROM OBSERVER! Omitting robot for now..")
+        }else {
+            robots.emplace_back(each, Team::them, getBall());
+        }
     }
+    // End of temporary fix
 
     us.reserve(amountUs);
     them.reserve(amountThem);


### PR DESCRIPTION
This code filters out robots with NaN-values, preventing the AI from crashing from these. #57 