### PR TITLE
Fix compilation error for compatibility with older proto versions

### DIFF
--- a/roboteam_interface/libs/interface_utils/include/roboteam_interface_utils/InterfaceDeclaration.h
+++ b/roboteam_interface/libs/interface_utils/include/roboteam_interface_utils/InterfaceDeclaration.h
@@ -73,7 +73,9 @@ struct InterfaceDropdown {
         proto::Dropdown dropdown;
 
         dropdown.set_text(this->text);
-        dropdown.mutable_options()->Add(options.begin(), options.end());
+        for(auto option : options){
+            dropdown.mutable_options()->Add(std::move(option));
+        }
 
         return dropdown;
     }
@@ -95,7 +97,9 @@ struct InterfaceRadio {
     proto::RadioButton toProto() const {
         proto::RadioButton radio;
 
-        radio.mutable_options()->Add(options.begin(), options.end());
+        for(auto option : options){
+            radio.mutable_options()->Add(std::move(option));
+        }
         return radio;
     }
 


### PR DESCRIPTION
The function I replaced is only allowed in newer proto versions; Was not compiling with proto 3.12.1 for me.