### PR TITLE
Replay tooling for roboteam_observer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(RELEASE_COMPILE_FLAGS "${CPP_STANDARD_FLAG}" "-fPIC" "-Ofast" "-march=native
 
 # Specify manually which compiler arguments we want to use, either DEBUG (default) or RELEASE ones
 # If you want to build in release mode, pass '-DCMAKE_BUILD_TYPE=RELEASE' as argument to cmake
-if (CMAKE_BUILD_TYPE MATCHES RELEASE)
+if (CMAKE_BUILD_TYPE MATCHES RELEASE OR CMAKE_BUILD_TYPE MATCHES Release)
     message("Building in release mode")
 
     set(COMPILER_FLAGS "${RELEASE_COMPILE_FLAGS}")

--- a/roboteam_interface/libs/logging/include/roboteam_logging/LogFileHeader.h
+++ b/roboteam_interface/libs/logging/include/roboteam_logging/LogFileHeader.h
@@ -8,10 +8,12 @@
 #include <proto/State.pb.h>
 #include <cassert>
 #include <cstring>
+#include <limits>
 namespace rtt{
 
     using logged_proto_type = proto::State;
     using logged_time_type = unsigned long long int;
+    static constexpr logged_time_type  INVALID_LOGGED_TIME = std::numeric_limits<logged_time_type>::max();
 
     static const char * DEFAULT_LOGFILE_HEADER_NAME = "RTT_LOG_FILE";
     static constexpr std::size_t LOGFILE_HEADER_NAME_SIZE = 12; //The number of characters used in the header.

--- a/roboteam_interface/libs/logging/src/LogFileReader.cpp
+++ b/roboteam_interface/libs/logging/src/LogFileReader.cpp
@@ -45,24 +45,25 @@ bool rtt::LogFileReader::open(const std::string &file_name) {
 }
 
 std::pair<rtt::logged_time_type, rtt::logged_proto_type> rtt::LogFileReader::readPacket(long file_offset) {
-    file->seekg(file_offset);
-    if(!file->eof()){
-        LogDataHeader dataHeader;
-        file->read(reinterpret_cast<char*>(&dataHeader),sizeof(LogDataHeader));
-        char * buffer = new char[dataHeader.message_size];
-        file->read(buffer,dataHeader.message_size);
-        rtt::logged_proto_type message;
-        bool success = message.ParseFromArray(buffer,dataHeader.message_size);
-        delete[] buffer;
-        if(success){
-            return std::make_pair(dataHeader.timestamp,message);
-        }else{
-            return std::make_pair(-1,rtt::logged_proto_type());
+    if(file_offset != index.back()){
+        file->seekg(file_offset);
+        if(!file->eof()){
+            LogDataHeader dataHeader;
+            file->read(reinterpret_cast<char*>(&dataHeader),sizeof(LogDataHeader));
+            char * buffer = new char[dataHeader.message_size];
+            file->read(buffer,dataHeader.message_size);
+            rtt::logged_proto_type message;
+            bool success = message.ParseFromArray(buffer,dataHeader.message_size);
+            delete[] buffer;
+            if(success){
+                return std::make_pair(dataHeader.timestamp,message);
+            }else{
+                return std::make_pair(INVALID_LOGGED_TIME,rtt::logged_proto_type());
+            }
         }
-
     }
     file->clear();
-    return std::make_pair(-1,rtt::logged_proto_type());
+    return std::make_pair(INVALID_LOGGED_TIME,rtt::logged_proto_type());
 }
 
 bool rtt::LogFileReader::indexFile() {

--- a/roboteam_networking/include/RobotFeedbackNetworker.hpp
+++ b/roboteam_networking/include/RobotFeedbackNetworker.hpp
@@ -6,7 +6,12 @@
 #include <utils/Publisher.hpp>
 #include <utils/Subscriber.hpp>
 
+#include <proto/RobotFeedback.pb.h>
+
 namespace rtt::net {
+
+proto::RobotsFeedback feedbackToProto(const rtt::RobotsFeedback& robotsFeedback);
+rtt::RobotsFeedback protoFeedbackToRobotsFeedback(const proto::RobotsFeedback& protoFeedbacks);
 
 class RobotFeedbackPublisher : private utils::Publisher {
    public:

--- a/roboteam_networking/proto/State.proto
+++ b/roboteam_networking/proto/State.proto
@@ -9,6 +9,7 @@ import "messages_robocup_ssl_geometry.proto";
 
 import "Handshake.proto";
 import "UiOptions.proto";
+import "RobotFeedback.proto";
 
 package proto;
 
@@ -22,6 +23,7 @@ message State {
     SSL_Referee referee = 7; //TODO: later change to a custom referee type
     repeated SSL_WrapperPacket processed_vision_packets = 10;
     repeated SSL_Referee processed_referee_packets = 11;
+    repeated RobotsFeedback processed_feedback_packets = 12;
 }
 
 message ModuleState {

--- a/roboteam_networking/src/RobotFeedbackNetworker.cpp
+++ b/roboteam_networking/src/RobotFeedbackNetworker.cpp
@@ -1,6 +1,5 @@
 #include <RobotFeedbackNetworker.hpp>
 
-#include <proto/RobotFeedback.pb.h>
 
 namespace rtt::net {
 

--- a/roboteam_world/CMakeLists.txt
+++ b/roboteam_world/CMakeLists.txt
@@ -23,3 +23,22 @@ target_include_directories(roboteam_observer
         )
 
 target_compile_options(roboteam_observer PRIVATE "${COMPILER_FLAGS}")
+
+add_executable(roboteam_observerReplayLog
+        src/replayLog.cpp
+        src/Handler.cpp
+        )
+
+target_link_libraries(roboteam_observerReplayLog
+        PRIVATE observer
+        PRIVATE roboteam_networking
+        PRIVATE roboteam_utils
+        PRIVATE roboteam_logging
+        PRIVATE Qt5::Network
+        )
+target_include_directories(roboteam_observerReplayLog
+        PRIVATE include/roboteam_observer
+        INTERFACE include
+        )
+
+target_compile_options(roboteam_observerReplayLog PRIVATE "${COMPILER_FLAGS}")

--- a/roboteam_world/include/roboteam_observer/Handler.h
+++ b/roboteam_world/include/roboteam_observer/Handler.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include <exception>
 #include <roboteam_logging/LogFileReader.h>
+#include <roboteam_logging/LogFileWriter.h>
 
 class Handler {
    private:
@@ -25,6 +26,9 @@ class Handler {
     Observer observer;
     std::vector<rtt::RobotsFeedback> receivedRobotData;
     std::mutex sub_mutex;
+
+    static std::optional<rtt::LogFileWriter> fileWriter;
+
    public:
     Handler() = default;
 

--- a/roboteam_world/include/roboteam_observer/Handler.h
+++ b/roboteam_world/include/roboteam_observer/Handler.h
@@ -12,7 +12,7 @@
 #include <memory>
 #include <vector>
 #include <exception>
-
+#include <roboteam_logging/LogFileReader.h>
 
 class Handler {
    private:
@@ -34,6 +34,7 @@ class Handler {
     bool initializeNetworkers();
     bool setupSSLClients(std::string visionip, std::string refereeip, int visionport, int refereeport);
 
+    void startReplay(rtt::LogFileReader& reader);
     void start(std::string visionip, std::string refereeip, int visionport, int refereeport, bool shouldLog = false);
     std::vector<proto::SSL_WrapperPacket> receiveVisionPackets();
     std::vector<proto::SSL_Referee> receiveRefereePackets();

--- a/roboteam_world/observer/include/observer/filters/vision/PosVelFilter1D.h
+++ b/roboteam_world/observer/include/observer/filters/vision/PosVelFilter1D.h
@@ -11,6 +11,7 @@
 class PosVelFilter1D {
  public:
   PosVelFilter1D() = default;
+  virtual ~PosVelFilter1D() = default;
   PosVelFilter1D(const Eigen::Vector2d &initialState, const Eigen::Matrix2d& initialCovariance,
                  double modelError, double measurementError, const Time& timeStamp);
   /**

--- a/roboteam_world/observer/src/Observer.cpp
+++ b/roboteam_world/observer/src/Observer.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "Observer.h"
+#include <RobotFeedbackNetworker.hpp>
 
 proto::State
 Observer::process(const std::vector<proto::SSL_WrapperPacket>& visionPackets, const std::vector<proto::SSL_Referee>& refereePackets,
@@ -12,8 +13,6 @@ Observer::process(const std::vector<proto::SSL_WrapperPacket>& visionPackets, co
     proto::State state;
     proto::World world = visionFilter.process(visionPackets,robotData);
     updateReferee(refereePackets);
-
-
 
     state.mutable_last_seen_world()->CopyFrom(world);
     state.mutable_command_extrapolated_world()->CopyFrom(world);//TODO; actually do extrapolation
@@ -42,7 +41,11 @@ Observer::process(const std::vector<proto::SSL_WrapperPacket>& visionPackets, co
     }
     for(const auto& refpacket : refereePackets){
         proto::SSL_Referee * packet = state.add_processed_referee_packets();
-        packet->CopyFrom(refpacket);    }
+        packet->CopyFrom(refpacket);
+    }
+    for(const auto& data : robotData){
+        state.mutable_processed_feedback_packets()->Add(rtt::net::feedbackToProto(data));
+    }
     return state;
 }
 

--- a/roboteam_world/observer/src/filters/vision/robot/CameraRobotFilter.cpp
+++ b/roboteam_world/observer/src/filters/vision/robot/CameraRobotFilter.cpp
@@ -92,7 +92,7 @@ FilteredRobot CameraRobotFilter::estimate(const Time &time) const {
 bool CameraRobotFilter::acceptObservation(const RobotObservation& observation) const{
   double angleDif = abs(rtt::Angle(angleFilter.getPosition()-observation.orientation));
   double posDifSq = (observation.position-positionFilter.getPosition()).squaredNorm();
-  return posDifSq<0.4*0.4 && angleDif < M_PI_2;
+  return posDifSq<0.4*0.4 && angleDif < M_PI_2; //TODO: remove hardcoded constants
 }
 
 RobotVel CameraRobotFilter::velocityEstimate(const Time &time) const {

--- a/roboteam_world/src/Handler.cpp
+++ b/roboteam_world/src/Handler.cpp
@@ -6,6 +6,9 @@
 #include <proto/messages_robocup_ssl_wrapper.pb.h>
 
 #include <roboteam_logging/LogFileWriter.h>
+#include <csignal>
+
+std::optional<rtt::LogFileWriter> Handler::fileWriter = std::nullopt;
 
 void Handler::start(std::string visionip, std::string refereeip, int visionport, int refereeport, bool shouldLog) {
     if (!initializeNetworkers()) {
@@ -17,7 +20,6 @@ void Handler::start(std::string visionip, std::string refereeip, int visionport,
 
     roboteam_utils::Timer t;
 
-    std::optional<rtt::LogFileWriter> fileWriter = std::nullopt;
 
     if (shouldLog) {
         auto now = Time::now();
@@ -31,6 +33,23 @@ void Handler::start(std::string visionip, std::string refereeip, int visionport,
         std::string file_name = "world_log_" + std::to_string(days) + "_" +std::to_string(hours) + "_" + std::to_string(minutes) +"_" + std::to_string(seconds) + "_" + std::to_string(mili)+".log";
         fileWriter = rtt::LogFileWriter();
         fileWriter.value().open(file_name);
+        //Create a signal handler so that when we crash data is still saved,
+        // so that the file is still closed when the program is unexpectedly terminated or an error is thrown
+        //If we do not do this, the filestream buffer may contain the messages which caused the crash,
+        // making it impossible to debug the issue afterwards
+        auto signalHandler = [](int signum){
+            if(Handler::fileWriter.has_value()){
+                Handler::fileWriter->close();
+            }
+            exit(signum);
+        };
+        std::signal(SIGABRT,signalHandler);
+        std::signal(SIGTERM,signalHandler);
+        std::signal(SIGSEGV,signalHandler);
+        std::signal(SIGFPE,signalHandler);
+        std::signal(SIGILL,signalHandler);
+        std::signal(SIGKILL,signalHandler);
+        std::signal(SIGQUIT,signalHandler);
     }
 
     // Feedback for user
@@ -70,7 +89,7 @@ void Handler::start(std::string visionip, std::string refereeip, int visionport,
                 std::lock_guard guard(sub_mutex);
                 std::swap(robothub_info, this->receivedRobotData);
             }
-
+            //TODO: try-catch here?
             auto state = observer.process(vision_packets,referee_packets,robothub_info); //TODO: fix time extrapolation
             std::size_t iterations = 0;
             bool sent = false;

--- a/roboteam_world/src/Handler.cpp
+++ b/roboteam_world/src/Handler.cpp
@@ -187,8 +187,12 @@ void Handler::startReplay(rtt::LogFileReader& reader) {
 
      std::vector<proto::SSL_WrapperPacket> visionPackets(state.processed_vision_packets().begin(),state.processed_vision_packets().end());
      std::vector<proto::SSL_Referee> refereePackets(state.processed_referee_packets().begin(),state.processed_referee_packets().end());
-     //TODO: also store robothub feedback which was processed in State!
-     auto check = observer.process(visionPackets,refereePackets,{});
+     std::vector<rtt::RobotsFeedback> feedbackPackets;
+     for(const auto& feedback : state.processed_feedback_packets()){
+         feedbackPackets.push_back(rtt::net::protoFeedbackToRobotsFeedback(feedback));
+     }
+
+     auto check = observer.process(visionPackets,refereePackets,feedbackPackets);
 
      numMessagesProcessed++;
      std::cout<<"Num Messages processed: "<< numMessagesProcessed<<"\n";

--- a/roboteam_world/src/replayLog.cpp
+++ b/roboteam_world/src/replayLog.cpp
@@ -1,0 +1,24 @@
+//
+// Created by rolf on 14-5-23.
+//
+
+#include "Handler.h"
+#include <roboteam_logging/LogFileReader.h>
+
+using rtt::LogFileReader;
+int main(int argc, char** argv) {
+    const std::vector<std::string> args(argv, argv + argc);
+    if(args.size() != 2){
+        std::cout << "Usage: ./roboteam_observerReplayLog <logfile>" << std::endl;
+        return EXIT_FAILURE;
+    }
+    LogFileReader reader;
+    bool good = reader.open(args[1]);
+    if(!good){
+        return EXIT_FAILURE;
+    }
+    Handler handler;
+    handler.startReplay(reader);
+    reader.close();
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This pull requests does the following, mostly related things:
- Adds an executable which exactly replays roboteam_observer with a logfile for debugging purposes.
- Adds  Signal Handlers so that logfiles are saved upon crashes of roboteam_observer
- Stores the complete input of roboteam_observer in the state
- Makes the LogReader able to read partially-correct logs
- Fixes a few random code-quality things I came across.
