### PR TITLE
[roboteam_ai] Fixed bug where the ZMQ channel for the blue color is being obtained by default when booting AI

### DIFF
--- a/roboteam_ai/src/utilities/Settings.cpp
+++ b/roboteam_ai/src/utilities/Settings.cpp
@@ -26,7 +26,7 @@ void GameSettings::setPrimaryAI(bool value) {  primaryAI = value; }
 bool GameSettings::isYellow() { return yellow; }
 
 bool GameSettings::setYellow(bool isYellow) {
-    if (ai::io::io.obtainTeamColorChannel(yellow)) {
+    if (ai::io::io.obtainTeamColorChannel(isYellow)) {
         yellow = isYellow;
         return true;
     }


### PR DESCRIPTION
Fixed bug where the channel for the blue color is being obtained by default when booting AI.

In Settings.cpp, a team is `blue` by default. When the AI is initialized, it calls `GameSettings::setYellow(newColor)`. This calls `io.obtainTeamColorChannel`. However, it doesn't pass the `newColor` as argument, it passes the current team color, which is always `blue`. So if you start AI as `yellow`, it incorrectly obtains the `blue` channel. This leads to the following error messages

![image](https://github.com/RoboTeamTwente/roboteam/assets/5947757/9907e267-14fa-4b1e-a4a0-6613760b62aa)
