### PR TITLE
fixed robothub changing to the wrong mode.

### DIFF
--- a/roboteam_robothub/src/RobotHub.cpp
+++ b/roboteam_robothub/src/RobotHub.cpp
@@ -197,7 +197,7 @@ void RobotHub::onRobotCommands(const rtt::RobotCommands &commands, rtt::Team col
 void RobotHub::onSettings(const proto::GameSettings &_settings) {
     this->settings = _settings;
 
-    utils::RobotHubMode newMode = settings.robot_hub_mode() ? utils::RobotHubMode::BASESTATION : utils::RobotHubMode::SIMULATOR;
+    utils::RobotHubMode newMode = settings.robot_hub_mode() ? utils::RobotHubMode::SIMULATOR : utils::RobotHubMode::BASESTATION;
 
     this->mode = newMode;
     this->statistics.robotHubMode = newMode;


### PR DESCRIPTION
robothub would send as basestation when ai was on simulation and vice versa. Fixed by interchanging the modes when setting newMode in RobotHub::onSettings in RobotHub.cpp

### Comments for the reviewer
- 

### Pre pull request checklist:

###### Code Quality
- [x] Is the code is understandable and easy to read
- [x] Changes to the code comply with set clang-format rules
- [x] No use of manual memory control (e.g new/malloc/colloc etc)
- [x] Are (only) smart pointers used?

###### Testing
- [x] All tests are passing.
- [x] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!) - not necessary
- [x] I tested my changes manually (Describe how, to what extent etc.) - simulation takes commands from Robothub again

###### Commit Messages
- [x] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [x] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
