### PR TITLE
Fix ai tests linking error

### DIFF
--- a/roboteam_ai/CMakeLists.txt
+++ b/roboteam_ai/CMakeLists.txt
@@ -409,7 +409,6 @@ target_link_libraries(roboteam_ai_tests
         PRIVATE Qt5::Widgets
         PRIVATE roboteam_networking
         # Watch out! The order of these libraries apparently matters!
-        PRIVATE roboteam_ai_interface
         PRIVATE roboteam_ai_plays
         PRIVATE roboteam_ai_world
         PRIVATE roboteam_ai_roles
@@ -421,6 +420,7 @@ target_link_libraries(roboteam_ai_tests
         PRIVATE roboteam_ai_skills
         PRIVATE roboteam_ai_control
         PRIVATE roboteam_interface_utils_lib
+        PRIVATE roboteam_ai_interface
         )
 
 target_compile_options(roboteam_ai_tests PRIVATE "${COMPILER_FLAGS}")

--- a/roboteam_ai/include/roboteam_ai/stp/skills/GoToPos.h
+++ b/roboteam_ai/include/roboteam_ai/stp/skills/GoToPos.h
@@ -24,12 +24,6 @@ class GoToPos : public Skill {
      * @return The name of this skill
      */
     const char* getName() override;
-
-    /**
-     * @brief Visualizes the path the robot will take
-     * @param info StpInfo struct with all relevant information for this robot and skill
-     */
-    void visualize(StpInfo const& info);
 };
 }  // namespace rtt::ai::stp::skill
 

--- a/roboteam_ai/src/control/positionControl/PositionControl.cpp
+++ b/roboteam_ai/src/control/positionControl/PositionControl.cpp
@@ -102,6 +102,9 @@ rtt::BB::CommandCollision PositionControl::computeAndTrackTrajectory(const rtt::
     commandCollision.robotCommand.velocity = trackingVelocityVector;
     commandCollision.robotCommand.targetAngle = trackingVelocity.rot;
 
+    interface::Input::addDrawing(interface::Drawing(interface::Visual::PATHFINDING, computedPaths[robotId], QColorConstants::Magenta, robotId,
+                                                    interface::Drawing::LINES_CONNECTED, 10, 10, 10));
+
     return commandCollision;
 }
 

--- a/roboteam_ai/src/stp/skills/GoToPos.cpp
+++ b/roboteam_ai/src/stp/skills/GoToPos.cpp
@@ -64,8 +64,6 @@ Status GoToPos::onUpdate(const StpInfo &info) noexcept {
     // forward the generated command to the ControlModule, for checking and limiting
     forwardRobotCommand(info.getCurrentWorld());
 
-    visualize(info);
-
     // Check if successful
     if ((info.getRobot().value()->getPos() - targetPos).length() <= stp::control_constants::GO_TO_POS_ERROR_MARGIN ||
         (info.getRobot().value()->hasBall() && (info.getRobot().value()->getPos() - targetPos).length() <= stp::control_constants::BALL_PLACEMENT_MARGIN)) {
@@ -76,11 +74,5 @@ Status GoToPos::onUpdate(const StpInfo &info) noexcept {
 }
 
 const char *GoToPos::getName() { return "Go To Position"; }
-
-void GoToPos::visualize(const StpInfo &info) {
-    auto pathPoints = info.getCurrentWorld()->getRobotPositionController()->getComputedPath(info.getRobot().value()->getId());
-    ai::interface::Input::addDrawing(interface::Drawing(interface::Visual::PATHFINDING, pathPoints, QColorConstants::Magenta, info.getRobot().value()->getId(),
-                                                        interface::Drawing::LINES_CONNECTED, 10, 10, 10));
-}
 
 }  // namespace rtt::ai::stp::skill

--- a/roboteam_robothub/scripts/sendFormationToSimulator.cpp
+++ b/roboteam_robothub/scripts/sendFormationToSimulator.cpp
@@ -2,8 +2,6 @@
 // Created by tijmen on 13-01-22.
 //
 
-#include <utilities.h>
-
 #include <simulation/SimulatorManager.hpp>
 
 #include <roboteam_utils/Teams.hpp>


### PR DESCRIPTION
### Comments for the reviewer
- The ai tests were not linking properly and gave an undefined reference to addDrawing from interface. I put the visualization of path planning in path planning rather than the goToPos skill because that makes more sense. The actual fix was to change the order of the linking libraries. I do not know why this fixes it so if someone does know please tell me.

### Pre pull request checklist:

###### Code Quality
- [x] Is the code is understandable and easy to read
- [x] Changes to the code comply with set clang-format rules
- [x] No use of manual memory control (e.g new/malloc/colloc etc)
- [x] Are (only) smart pointers used?

###### Testing
- [x] All tests are passing.
- [x] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [x] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [x] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [x] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
