### PR TITLE
Make sure that robots drive without GUI

### DIFF
--- a/roboteam_ai/src/interface/api/Output.cpp
+++ b/roboteam_ai/src/interface/api/Output.cpp
@@ -9,11 +9,11 @@
 namespace rtt::ai::interface {
 
 // these values are default initialized here, but will be updated once mainWidget.cpp constructs the PID widget.
-pidVals Output::numTreePID = pidVals(0.0, 0.0, 0.0);
-pidVals Output::receivePID = pidVals(0.0, 0.0, 0.0);
-pidVals Output::interceptPID = pidVals(0.0, 0.0, 0.0);
-pidVals Output::keeperPID = pidVals(0.0, 0.0, 0.0);
-pidVals Output::keeperInterceptPID = pidVals(0.0, 0.0, 0.0);
+pidVals Output::numTreePID = Constants::standardNumTreePID();
+pidVals Output::receivePID = Constants::standardReceivePID();
+pidVals Output::interceptPID = Constants::standardInterceptPID();
+pidVals Output::keeperPID = Constants::standardKeeperPID();
+pidVals Output::keeperInterceptPID = Constants::standardKeeperInterceptPID();
 
 rtt::Vector2 Output::markerPosition = {0, 0};  // initialize on middle of the field
 bool Output::useRefereeCommands = false;


### PR DESCRIPTION
When disabling the GUI, the robots suddenly can't drive to a target anymore. This happens because the PIDs are initialized to `(0,0,0)`, and only updated to usable values within the GUI code.. With this PR, the PIDs are initialized to the default ones defined in `rtt::ai::Constants`. Now the robots drive fine without GUI.