### PR TITLE
Rename install_UBUNTU_20_04.sh to install_UBUNTU_22_04.sh

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get install -y vim git cmake pkg-config python3 python3-pip ccache
 
 RUN git clone https://github.com/RoboTeamTwente/roboteam.git --recursive
 WORKDIR /roboteam
-RUN ./install_UBUNTU_20_04.sh
+RUN ./install_UBUNTU_22_04.sh
 RUN mkdir build 
 WORKDIR /roboteam/build
 RUN cmake .. -DCMAKE_BUILD_TYPE=Release && make -j$(nproc) roboteam_observer roboteam_ai roboteam_robothub


### PR DESCRIPTION
The original shell script was already renamed, but the Dockerfile not yet, causing the docker build action to fail.

### Comments for the reviewer
- The docker action broke, since the dockerfile could not find the dependencies shell file due to it being renamed in commit 6143254.

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [x] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
