### PR TITLE
Set default value for robot command parameters

### DIFF
--- a/roboteam_robothub/src/RobotHub.cpp
+++ b/roboteam_robothub/src/RobotHub.cpp
@@ -123,7 +123,11 @@ void RobotHub::sendCommandsToBasestation(const rtt::RobotCommands &commands, rtt
         command.header = REM_PACKET_TYPE_REM_ROBOT_COMMAND;
         command.toRobotId = robotCommand.id;
         command.toColor = color == rtt::Team::BLUE;
-        command.fromBS = true;
+        command.fromBS = false;
+        command.fromPC = true;
+        command.toPC = false;
+        command.toBS = false;
+        command.toBC = false;
         command.remVersion = REM_LOCAL_VERSION;
         // command.messageId = 0; TODO implement incrementing message id
         command.payloadSize = REM_PACKET_SIZE_REM_ROBOT_COMMAND;


### PR DESCRIPTION
This will (hopefully, most likely) fix the 'unhandled message 34' encoutered during buga and countless time afterwards