### PR TITLE
Adding a setup to run autoref without roboteam AI

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -75,11 +75,11 @@ NOTE: if you dont't specify COMMIT=<commit>, the default will be origin/main~1
 2. Start services:
 ```
 cd $ROBOTEAM_REPO/docker/runner
-docker compose --profile <simulator / diff / game> up -d
+docker compose --profile <simulator / diff / game / autoref> up -d
 ```
 When you want to stop services:
 ```
-docker compose --profile <simulator / diff /game> down
+docker compose --profile <simulator / diff / game / autoref> down
 ```
 
 Note: you may want to use `docker logs -t <container_name>` to see output of a container (service).

--- a/docker/runner/docker-compose.yml
+++ b/docker/runner/docker-compose.yml
@@ -90,7 +90,7 @@ services:
       - LD_LIBRARY_PATH=/home/roboteamtwente/lib/
     volumes:
       - ../../build/release/:/home/roboteamtwente/
-    profiles: ["game"]
+    profiles: ["game","autoref"]
 
   roboteam_robothub_sim:
     image: roboteamtwente/roboteam:development
@@ -164,7 +164,7 @@ services:
       - GRADLE_USER_HOME=/home/roboteamtwente/.cache # Cache gradle dependencies
     volumes:
       - ../../roboteam_autoref/:/home/roboteamtwente/
-    profiles: ["simulator","diff","game"]
+    profiles: ["simulator","diff","game","autoref"]
 
   erforce_autoref_sim:
     image: roboteamtwente/roboteam:development


### PR DESCRIPTION
During (practice) tournaments AutoRef might be used. For this it would be nice to run AutoRef and the observer without the need to run RoboTeam Twente's AI. This PR adds an way to do so.
